### PR TITLE
Develop

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   ],
   "require": {
     "findologic/libflexport": "^2.5",
-    "findologic/findologic-api": "^1.1"
+    "findologic/findologic-api": "v1.1.1"
   },
   "extra": {
     "shopware-plugin-class": "FINDOLOGIC\\FinSearch\\FinSearch",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e65b75a82ea5f930778ce0f14de914cd",
+    "content-hash": "b86dc21648e4eeb5d913342718bfbf6d",
     "packages": [
         {
             "name": "findologic/findologic-api",
-            "version": "v1.1.0",
+            "version": "v1.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/findologic/findologic-api.git",
-                "reference": "d1aa7c5b587a86f1f8cb9bb6fab34292a49b0100"
+                "reference": "2d465c5d9d0a5e513e08a75542d27afab101152f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/findologic/findologic-api/zipball/d1aa7c5b587a86f1f8cb9bb6fab34292a49b0100",
-                "reference": "d1aa7c5b587a86f1f8cb9bb6fab34292a49b0100",
+                "url": "https://api.github.com/repos/findologic/findologic-api/zipball/2d465c5d9d0a5e513e08a75542d27afab101152f",
+                "reference": "2d465c5d9d0a5e513e08a75542d27afab101152f",
                 "shasum": ""
             },
             "require": {
@@ -62,7 +62,7 @@
                 }
             ],
             "description": "Library for FINDOLOGIC API requests",
-            "time": "2020-01-22T11:45:55+00:00"
+            "time": "2020-02-12T09:13:48+00:00"
         },
         {
             "name": "findologic/libflexport",
@@ -522,16 +522,16 @@
     "packages-dev": [
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.5.3",
+            "version": "3.5.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "557a1fc7ac702c66b0bbfe16ab3d55839ef724cb"
+                "reference": "dceec07328401de6211037abbb18bda423677e26"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/557a1fc7ac702c66b0bbfe16ab3d55839ef724cb",
-                "reference": "557a1fc7ac702c66b0bbfe16ab3d55839ef724cb",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/dceec07328401de6211037abbb18bda423677e26",
+                "reference": "dceec07328401de6211037abbb18bda423677e26",
                 "shasum": ""
             },
             "require": {
@@ -569,7 +569,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2019-12-04T04:46:47+00:00"
+            "time": "2020-01-30T22:20:29+00:00"
         }
     ],
     "aliases": [],

--- a/src/Core/Content/Product/SalesChannel/Listing/SortingHandler/PriceSortingHandler.php
+++ b/src/Core/Content/Product/SalesChannel/Listing/SortingHandler/PriceSortingHandler.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FINDOLOGIC\FinSearch\Core\Content\Product\SalesChannel\Listing\SortingHandler;
+
+use FINDOLOGIC\Api\Requests\SearchNavigation\SearchNavigationRequest;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
+
+class PriceSortingHandler implements SortingHandlerInterface
+{
+    public function supportsSorting(FieldSorting $fieldSorting): bool
+    {
+        return ($fieldSorting->getField() === 'product.listingPrices');
+    }
+
+    public function generateSorting(FieldSorting $fieldSorting, SearchNavigationRequest $searchNavigationRequest): void
+    {
+        $searchNavigationRequest->setOrder('price ' . $fieldSorting->getDirection());
+    }
+}

--- a/src/Core/Content/Product/SalesChannel/Listing/SortingHandler/ProductNameSortingHandler.php
+++ b/src/Core/Content/Product/SalesChannel/Listing/SortingHandler/ProductNameSortingHandler.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FINDOLOGIC\FinSearch\Core\Content\Product\SalesChannel\Listing\SortingHandler;
+
+use FINDOLOGIC\Api\Requests\SearchNavigation\SearchNavigationRequest;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
+
+class ProductNameSortingHandler implements SortingHandlerInterface
+{
+    public function supportsSorting(FieldSorting $fieldSorting): bool
+    {
+        return ($fieldSorting->getField() === 'product.name');
+    }
+
+    public function generateSorting(FieldSorting $fieldSorting, SearchNavigationRequest $searchNavigationRequest): void
+    {
+        $searchNavigationRequest->setOrder('label ' . $fieldSorting->getDirection());
+    }
+}

--- a/src/Core/Content/Product/SalesChannel/Listing/SortingHandler/ReleaseDateSortingHandler.php
+++ b/src/Core/Content/Product/SalesChannel/Listing/SortingHandler/ReleaseDateSortingHandler.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FINDOLOGIC\FinSearch\Core\Content\Product\SalesChannel\Listing\SortingHandler;
+
+use FINDOLOGIC\Api\Requests\SearchNavigation\SearchNavigationRequest;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
+
+class ReleaseDateSortingHandler implements SortingHandlerInterface
+{
+    public function supportsSorting(FieldSorting $fieldSorting): bool
+    {
+        // Shopware currently does not support it so we return false here
+        return false;
+    }
+
+    public function generateSorting(FieldSorting $fieldSorting, SearchNavigationRequest $searchNavigationRequest): void
+    {
+        $searchNavigationRequest->setOrder('dateadded ' . $fieldSorting->getDirection());
+    }
+}

--- a/src/Core/Content/Product/SalesChannel/Listing/SortingHandler/ScoreSortingHandler.php
+++ b/src/Core/Content/Product/SalesChannel/Listing/SortingHandler/ScoreSortingHandler.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FINDOLOGIC\FinSearch\Core\Content\Product\SalesChannel\Listing\SortingHandler;
+
+use FINDOLOGIC\Api\Requests\SearchNavigation\SearchNavigationRequest;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
+
+class ScoreSortingHandler implements SortingHandlerInterface
+{
+    public function supportsSorting(FieldSorting $fieldSorting): bool
+    {
+        return ($fieldSorting->getField() === '_score');
+    }
+
+    public function generateSorting(FieldSorting $fieldSorting, SearchNavigationRequest $searchNavigationRequest): void
+    {
+        $searchNavigationRequest->setOrder('salesfrequency dynamic ' . $fieldSorting->getDirection());
+    }
+}

--- a/src/Core/Content/Product/SalesChannel/Listing/SortingHandler/SortingHandlerInterface.php
+++ b/src/Core/Content/Product/SalesChannel/Listing/SortingHandler/SortingHandlerInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FINDOLOGIC\FinSearch\Core\Content\Product\SalesChannel\Listing\SortingHandler;
+
+use FINDOLOGIC\Api\Requests\SearchNavigation\SearchNavigationRequest;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
+
+interface SortingHandlerInterface
+{
+    public function supportsSorting(FieldSorting $fieldSorting): bool;
+
+    public function generateSorting(
+        FieldSorting $fieldSorting,
+        SearchNavigationRequest $searchNavigationRequest
+    ): void;
+}

--- a/src/Findologic/Request/Handler/NavigationRequestHandler.php
+++ b/src/Findologic/Request/Handler/NavigationRequestHandler.php
@@ -80,6 +80,7 @@ class NavigationRequestHandler extends SearchNavigationRequestHandler
         $navigationRequest = $this->findologicRequestFactory->getInstance($request);
         $navigationRequest->setSelected('cat', $categoryPath);
         $this->setPaginationParams($event, $navigationRequest);
+        $this->addSorting($navigationRequest, $event->getCriteria());
 
         try {
             $response = $this->sendRequest($navigationRequest);

--- a/src/Findologic/Request/Handler/SearchRequestHandler.php
+++ b/src/Findologic/Request/Handler/SearchRequestHandler.php
@@ -20,8 +20,9 @@ use Symfony\Component\HttpFoundation\Request;
 class SearchRequestHandler extends SearchNavigationRequestHandler
 {
     /**
-     * @throws InconsistentCriteriaIdsException
      * @param ShopwareEvent|ProductSearchCriteriaEvent $event
+     *
+     * @throws InconsistentCriteriaIdsException
      */
     public function handleRequest(ShopwareEvent $event): void
     {
@@ -32,18 +33,19 @@ class SearchRequestHandler extends SearchNavigationRequestHandler
         $searchRequest = $this->findologicRequestFactory->getInstance($request);
         $searchRequest->setQuery((string)$request->query->get('search'));
         $this->setPaginationParams($event, $searchRequest);
+        $this->addSorting($searchRequest, $event->getCriteria());
 
         try {
             /** @var Xml21Response $response */
             $response = $this->sendRequest($searchRequest);
         } catch (ServiceNotAliveException $e) {
             $this->assignCriteriaToEvent($event, $originalCriteria);
+
             return;
         }
 
         $this->setSmartDidYouMeanExtension($event, $response, $request);
         $criteria = new Criteria($this->parseProductIdsFromResponse($response));
-
         $this->redirectOnLandingPage($response);
         $this->setPromotionExtension($event, $response);
 


### PR DESCRIPTION
* SW-381-sorting-products

* Use dev-SW-381-product-sorting branch for findologic-api

* Update composer dependency

* Removed composer.lock file

* Removed composer.lock file

* Re-added composer.lock file

* Update FINDOLOGIC-API to dev-master

* Require findologic-api v1.1.1

Co-authored-by: Dominik Brader <dominik@brader.co.at>